### PR TITLE
Dev4 - change to manifest to use development library

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 This is the home-assistant integration based on @alistair23 BLE implementation of Husqvarna bluetooth mowers
 https://github.com/alistair23/AutoMower-BLE
 
+NOTE - It is recommended to use the python library direct from the source tree, rather than pypi/pip libraries. This is due to the library being behind on pypi for legacy applications.
+I have included in this HACS repo manifest for Home Assistant/Python/PIP to install from the main repo above, so this should happen.
+If not, you need to manually update the library on your home assistant installation, in the location:
+  /usr/local/lib/python3.12/site-packages/automower_ble/
+(The newer version should NOT have request.py as a file so you can check if you are using the correct version)
+
 # Installation
 Just add this repo to the custom repos in HACS (https://hacs.xyz/docs/faq/custom_repositories/).
 

--- a/custom_components/husqvarna_automower_ble/config_flow.py
+++ b/custom_components/husqvarna_automower_ble/config_flow.py
@@ -103,7 +103,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            description_placeholders={"message": "Enter your device MAC address"}
+            description_placeholders={"message": "Enter your device MAC address"},
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_ADDRESS): str,

--- a/custom_components/husqvarna_automower_ble/config_flow.py
+++ b/custom_components/husqvarna_automower_ble/config_flow.py
@@ -85,14 +85,10 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
                 data={CONF_ADDRESS: self.address, CONF_CLIENT_ID: channel_id},
             )
 
-        self.context["title_placeholders"] = {
-            "name": title,
-        }
-
         self._set_confirm_only()
         return self.async_show_form(
             step_id="confirm",
-            description_placeholders=self.context["title_placeholders"],
+            description_placeholders={"message": "Power your mower on and enter the PIN so it is in pairing mode and click SUBMIT."}
         )
 
     async def async_step_user(
@@ -107,6 +103,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
+            description_placeholders={"message": "Enter your device MAC address"}
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_ADDRESS): str,

--- a/custom_components/husqvarna_automower_ble/config_flow.py
+++ b/custom_components/husqvarna_automower_ble/config_flow.py
@@ -88,7 +88,8 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
         self._set_confirm_only()
         return self.async_show_form(
             step_id="confirm",
-            description_placeholders={"message": "Power your mower on and enter the PIN so it is in pairing mode and click SUBMIT."}
+            description_placeholders={"message": "Power your mower on and enter the PIN so it is in pairing mode and click SUBMIT."},
+            description="Power your mower on and enter the PIN so it is in pairing mode and click SUBMIT."
         )
 
     async def async_step_user(
@@ -104,6 +105,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             description_placeholders={"message": "Enter your device MAC address"},
+            description="Enter your device MAC address",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_ADDRESS): str,

--- a/custom_components/husqvarna_automower_ble/manifest.json
+++ b/custom_components/husqvarna_automower_ble/manifest.json
@@ -13,6 +13,6 @@
   "documentation": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/",
   "issue_tracker": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/issues",
   "iot_class": "local_polling",
-  "requirements": ["automower-ble==0.1.35"],
-  "version": "0.0.6"
+  "requirements": [automower_ble @ "git+https://github.com/alistair23/AutoMower-BLE.git@master"],
+  "version": "0.0.7"
 }

--- a/custom_components/husqvarna_automower_ble/manifest.json
+++ b/custom_components/husqvarna_automower_ble/manifest.json
@@ -13,6 +13,6 @@
   "documentation": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/",
   "issue_tracker": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/issues",
   "iot_class": "local_polling",
-  "requirements": ["git+https://github.com/alistair23/AutoMower-BLE.git@master#automower_ble==0.2.0"],
+  "requirements": ["git+https://github.com/alistair23/AutoMower-BLE.git@main#automower_ble==0.2.0"],
   "version": "0.0.7"
 }

--- a/custom_components/husqvarna_automower_ble/manifest.json
+++ b/custom_components/husqvarna_automower_ble/manifest.json
@@ -13,6 +13,6 @@
   "documentation": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/",
   "issue_tracker": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/issues",
   "iot_class": "local_polling",
-  "requirements": ["automower-ble==0.1.33"],
-  "version": "0.0.5"
+  "requirements": ["automower-ble==0.1.35"],
+  "version": "0.0.6"
 }

--- a/custom_components/husqvarna_automower_ble/manifest.json
+++ b/custom_components/husqvarna_automower_ble/manifest.json
@@ -13,6 +13,6 @@
   "documentation": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/",
   "issue_tracker": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/issues",
   "iot_class": "local_polling",
-  "requirements": [automower_ble @ "git+https://github.com/alistair23/AutoMower-BLE.git@master"],
+  "requirements": ["git+https://github.com/alistair23/AutoMower-BLE.git@master"],
   "version": "0.0.7"
 }

--- a/custom_components/husqvarna_automower_ble/manifest.json
+++ b/custom_components/husqvarna_automower_ble/manifest.json
@@ -13,6 +13,6 @@
   "documentation": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/",
   "issue_tracker": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/issues",
   "iot_class": "local_polling",
-  "requirements": ["git+https://github.com/alistair23/AutoMower-BLE.git@master"],
+  "requirements": ["git+https://github.com/alistair23/AutoMower-BLE.git@master#automower_ble==0.2.0"],
   "version": "0.0.7"
 }

--- a/custom_components/husqvarna_automower_ble/sensor.py
+++ b/custom_components/husqvarna_automower_ble/sensor.py
@@ -172,7 +172,6 @@ class AutomowerSensorEntity(CoordinatorEntity, SensorEntity):
         try:
             # trying alternative search
             stats_dict  = self.coordinator.data["statistics"]
-            _LOGGER.debug("Attempting deep search in array for key - data in struct - " + str(type(stats_dict)))
             self._attr_native_value = stats_dict[self.entity_description.key]
             self._attr_available = self._attr_native_value is not None
             _LOGGER.debug("Update sensor %s with value %s", self.entity_description.key, self._attr_native_value)

--- a/custom_components/husqvarna_automower_ble/sensor.py
+++ b/custom_components/husqvarna_automower_ble/sensor.py
@@ -85,7 +85,7 @@ MOWER_SENSORS = [
         device_class=None,
         state_class=SensorStateClass.TOTAL,
         entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:crash",
+        icon="mdi:alert-circle",
     ),
     SensorEntityDescription(
         name="Total number of charging cycles",
@@ -94,7 +94,7 @@ MOWER_SENSORS = [
         device_class=None,
         state_class=SensorStateClass.TOTAL,
         entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:charge",
+        icon="mdi:repeat-variant",
     ),
     SensorEntityDescription(
         name="Total cutting blade usage",


### PR DESCRIPTION
Main change is using the development library for automower_ble rather than pip libraries.
Should allow newer models to be discovered and various code changes and fixes
