### PR TITLE
Enable optional PIN request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 This is the home-assistant integration based on @alistair23 BLE implementation of Husqvarna bluetooth mowers
 https://github.com/alistair23/AutoMower-BLE
 
+** THIS IS DEVELOPMENTAL/DEBUG HACS integration so expect errors! **
+
 NOTE - It is recommended to use the python library direct from the source tree, rather than pypi/pip libraries. This is due to the library being behind on pypi for legacy applications.
 I have included in this HACS repo manifest for Home Assistant/Python/PIP to install from the main repo above, so this should happen.
 If not, you need to manually update the library on your home assistant installation, in the location:

--- a/custom_components/husqvarna_automower_ble/__init__.py
+++ b/custom_components/husqvarna_automower_ble/__init__.py
@@ -28,16 +28,19 @@ PLATFORMS: list[Platform] = [
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Husqvarna Autoconnect Bluetooth from a config entry."""
     address = entry.data[CONF_ADDRESS]
-    #pin = entry.data[CONF_PIN]
+    pin = entry.data[CONF_PIN]
     channel_id = entry.data[CONF_CLIENT_ID]
 
     LOGGER.info(STARTUP_MESSAGE)
 
-    mower = Mower(channel_id, address)
+    if pin != 0:
+        mower = Mower(channel_id, address, pin)
+    else:
+        mower = Mower(channel_id, address)
 
     await close_stale_connections_by_address(address)
 
-    LOGGER.debug("connecting to %s with channel ID %s", address, str(channel_id))
+    LOGGER.debug("connecting to %s with channel ID %s", address, str(channel_id), str(pin))
     device = bluetooth.async_ble_device_from_address(
         hass, address, connectable=True
     ) or await get_device(address)

--- a/custom_components/husqvarna_automower_ble/config_flow.py
+++ b/custom_components/husqvarna_automower_ble/config_flow.py
@@ -101,6 +101,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             self.address = user_input[CONF_ADDRESS]
+            self.pin = user_input[CONF_PIN]
             await self.async_set_unique_id(self.address, raise_on_progress=False)
             self._abort_if_unique_id_configured()
             return await self.async_step_confirm()
@@ -110,7 +111,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_ADDRESS): str,
-                    vol.Optional(CONF_PIN): str,
+                    vol.Optional(CONF_PIN, default=0): int,
                 },
             ),
             errors=errors

--- a/custom_components/husqvarna_automower_ble/sensor.py
+++ b/custom_components/husqvarna_automower_ble/sensor.py
@@ -71,7 +71,7 @@ MOWER_SENSORS = [
         icon="mdi:timer",
     ),
     SensorEntityDescription(
-        name="Total searcing time",
+        name="Total searching time",
         key="totalSearchingTime",
         unit_of_measurement=UnitOfTime.SECONDS,
         device_class=SensorDeviceClass.DURATION,


### PR DESCRIPTION
This seems to work with both PIN entry for Easylife. Defaults to no PIN.

Not for merging, but working for me.