### PR TITLE
Dev9 -Merging fixes to newer homeassistant (to avoid blocking calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ In addition to that, extra sensors are created that allow you to monitor battery
  - Hassfest validation still fails due to formatting of the requirements in custom_components, see https://github.com/home-assistant/actions/issues/92 |
 | 7/Apr/24 | - Updated README
  - 
-
+| 12/Jun/25 | - Various bugfixes to allow for newer Home Assistant versions (2025.3.3 and above) and to allow config flow fixes since blocking issues.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ In addition to that, extra sensors are created that allow you to monitor battery
 
 # Release notes/updates
 
-25/Oct/24
-	- Added new return to dock status as implement in HA, so bumping required release for HA up to 2024.9
-	- Hassfest validation still fails due to formatting of the requirements in custom_components, see https://github.com/home-assistant/actions/issues/92
+| Release Date | Changes |
+|-----:|-----------|
+| 25/Oct/24 | - Added new return to dock status as implement in HA, so bumping required release for HA up to 2024.9
+ - Hassfest validation still fails due to formatting of the requirements in custom_components, see https://github.com/home-assistant/actions/issues/92 |
+| 7/Apr/24 | - Updated README
+ - 
 

--- a/custom_components/husqvarna_automower_ble/__init__.py
+++ b/custom_components/husqvarna_automower_ble/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+import asyncio
+
 from automower_ble.mower import Mower
 from bleak import BleakError
 from bleak_retry_connector import close_stale_connections_by_address, get_device
@@ -35,8 +37,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if pin != 0:
         mower = Mower(channel_id, address, pin)
+        mower = await asyncio.to_thread(Mower, channel_id, address, pin)
     else:
-        mower = Mower(channel_id, address)
+        await asyncio.to_thread(Mower, channel_id, address)
 
     await close_stale_connections_by_address(address)
 

--- a/custom_components/husqvarna_automower_ble/__init__.py
+++ b/custom_components/husqvarna_automower_ble/__init__.py
@@ -51,6 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise ConfigEntryNotReady("Couldn't find device")
     except (BleakError, TimeoutError) as ex:
         raise ConfigEntryNotReady("Couldn't find device") from ex
+        return
 
     LOGGER.debug("connected and paired")
 

--- a/custom_components/husqvarna_automower_ble/__init__.py
+++ b/custom_components/husqvarna_automower_ble/__init__.py
@@ -36,10 +36,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     LOGGER.info(STARTUP_MESSAGE)
 
     if pin != 0:
-        mower = Mower(channel_id, address, pin)
         mower = await asyncio.to_thread(Mower, channel_id, address, pin)
     else:
-        await asyncio.to_thread(Mower, channel_id, address)
+        mower = await asyncio.to_thread(Mower, channel_id, address)
 
     await close_stale_connections_by_address(address)
 

--- a/custom_components/husqvarna_automower_ble/manifest.json
+++ b/custom_components/husqvarna_automower_ble/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andyb2000/HACS-husqvarna_automower_ble/issues",
   "requirements": ["git+https://github.com/alistair23/AutoMower-BLE.git@main"],
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/custom_components/husqvarna_automower_ble/sensor.py
+++ b/custom_components/husqvarna_automower_ble/sensor.py
@@ -268,10 +268,11 @@ class AutomowerSensorEntity(CoordinatorEntity, SensorEntity):
             return self._attr_native_value
         except KeyError:
             self._attr_native_value = None
-            _LOGGER.error(
-                "%s not a valid attribute (in _update_attr)",
-                self.entity_description.key,
-            )
+            #_LOGGER.error(
+            #    "%s not a valid attribute (in _update_attr)",
+            #    self.entity_description.key,
+            #)
+            # Removing logger to silently switch to alternative method
             # pass to allow it to try the next method
             pass
         try:

--- a/custom_components/husqvarna_automower_ble/sensor.py
+++ b/custom_components/husqvarna_automower_ble/sensor.py
@@ -192,10 +192,10 @@ class AutomowerSensorEntity(CoordinatorEntity, SensorEntity):
             return self._attr_native_value
         except KeyError:
             self._attr_native_value = None
-            _LOGGER.error(
-                "%s not a valid attribute (in state)",
-                self.entity_description.key,
-            )
+            #_LOGGER.error(
+            #    "%s not a valid attribute (in state)",
+            #    self.entity_description.key,
+            #)
             # pass to allow it to try the next method
             pass
         try:

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Husqvarna Automower BLE",
   "country": "ALL",
-  "homeassistant": "2024.9.1"
+  "homeassistant": "2025.3.3"
 }


### PR DESCRIPTION
Fixes bugs with blocking calls #39 
Fixes additional error logging (not needed) #41 
Implements #24 and #29 for "RETURNING" state
![image](https://github.com/user-attachments/assets/a97939c7-8457-4acb-8652-2b16c45eec90)
Also fixes config_flow not working (PIN entry) for automatic MAC discovery
